### PR TITLE
perf(install_sdk): remove flutter doctor

### DIFF
--- a/src/commands/install_sdk.yml
+++ b/src/commands/install_sdk.yml
@@ -21,4 +21,3 @@ steps:
           exit 1
         fi
         echo 'export PATH=~/development/flutter/bin:$PATH' >> $BASH_ENV
-  - run: flutter doctor


### PR DESCRIPTION
Running `flutter doctor` might be useful for debugging but it's not needed in most cases. I've experienced it taking up to 17 seconds, which adds up to some significant ammount over time. 

The user can add this command by him/herself, as it's just an _one liner_.

![image](https://user-images.githubusercontent.com/7662016/159133014-07c48f3c-6230-434c-86c7-cf382fb242cd.png)
![image](https://user-images.githubusercontent.com/7662016/159133026-47a0fa32-751f-4dc1-b294-70fa32a55718.png)
![image](https://user-images.githubusercontent.com/7662016/159133041-0b17af92-4328-4928-a7c3-4108ae18ab78.png)
