### PR TITLE
✏️ fix: use flutter_version instead of version

### DIFF
--- a/src/examples/install_for_android_machine.yml
+++ b/src/examples/install_for_android_machine.yml
@@ -11,7 +11,7 @@ usage:
         name: android/android-machine
       steps:
         - flutter/install_sdk_and_pub:
-            version: 2.2.3
+            flutter_version: 2.2.3
         - flutter/install_android_gradle
         - flutter/install_android_gem
         - run:

--- a/src/examples/install_for_macos.yml
+++ b/src/examples/install_for_macos.yml
@@ -10,7 +10,7 @@ usage:
         xcode: 12.5.1
       steps:
         - flutter/install_sdk_and_pub:
-            version: 2.2.3
+            flutter_version: 2.2.3
         - flutter/install_ios_pod
         - flutter/install_ios_gem
         - run:


### PR DESCRIPTION
The example uses  `version` (❌) for the `flutter/install_sdk_and_pub` job,
however, that is incorrect it should be  `flutter_version` (✅).

The `flutter/install_sdk_and_pub` job only has the following parameters:
* app-dir
* cache-version
* flutter_version
* install-location