### PR TITLE
chore: update codeowners to images

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,1 @@
-# Ping these folks when changes are made to this repository
-* @CircleCI-Public/orb-publishers
-
-# We can also add orb-specifc codeowners at some point if desirable
+*	@CircleCI-Public/images


### PR DESCRIPTION
flutter-orb is now owned by images, therefore the codeowners file is being changed