### PR TITLE
Add `--repo-update` to `install_ios_pod`

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -16,6 +16,7 @@ jobs:
       - flutter/install_sdk_and_pub:
           app-dir: ./sample
       - flutter/install_ios_pod:
+          repo-update: true
           app-dir: ./sample
       - flutter/install_ios_gem:
           app-dir: ./sample
@@ -33,6 +34,7 @@ jobs:
           channel: beta
           version: 3.27.0-0.1.pre
       - flutter/install_ios_pod:
+          repo-update: true
           app-dir: ./sample
       - flutter/install_ios_gem:
           app-dir: ./sample

--- a/src/commands/install_ios_pod.yml
+++ b/src/commands/install_ios_pod.yml
@@ -10,9 +10,9 @@ parameters:
     description: Change the default cache version if you need to clear the cache for any reason.
     type: string
   repo-update:
-            default: false
-            description: Whether to run 'pod install' with the '--repo-update' option.
-            type: boolean
+    default: false
+    description: Whether to run 'pod install' with the '--repo-update' option.
+    type: boolean
 steps:
   - restore_cache:
       keys:

--- a/src/commands/install_ios_pod.yml
+++ b/src/commands/install_ios_pod.yml
@@ -9,13 +9,17 @@ parameters:
     default: v1
     description: Change the default cache version if you need to clear the cache for any reason.
     type: string
+  repo-update:
+            default: false
+            description: Whether to run 'pod install' with the '--repo-update' option.
+            type: boolean
 steps:
   - restore_cache:
       keys:
         - 'pod-<<parameters.cache-version>>-{{ checksum "<< parameters.app-dir >>/ios/Podfile.lock" }}'
   - run:
       name: Install Dependencies
-      command: pod install
+      command: pod install <<#parameters.repo-update>>--repo-update<</parameters.repo-update>>
       working_directory: <<parameters.app-dir>>/ios
   - save_cache:
       paths:


### PR DESCRIPTION
## Description

This PR adds the `--repo-update` to the `install_ios_pod` command.

### Usages

```
flutter/install_ios_pod
```
Would still function as this command previously did

```
- flutter/install_ios_pod:
    repo-update: true
```
Would add the `--repo-update` option 