### PR TITLE
fix: flutter installation fail

### DIFF
--- a/src/scripts/install-sdk.sh
+++ b/src/scripts/install-sdk.sh
@@ -11,7 +11,7 @@ function install_flutter() {
 
   baseurl="https://storage.googleapis.com/flutter_infra_release/releases/stable"
 
-  fullurl="$baseurl/$uname/${version}_$ORB_VAL_FLUTTER_SK_VERSION-stable.${suffix}"
+  fullurl="$baseurl/$uname/${version}_$ORB_VAL_FLUTTER_SDK_VERSION-stable.${suffix}"
 
   curl -o "flutter_sdk.${suffix}" "$fullurl"
 }


### PR DESCRIPTION
- `ORB_VAL_FLUTTER_SK_VERSION` type wrong in `install-sdk.sh`, should be `ORB_VAL_FLUTTER_SDK_VERSION`, relate to #36